### PR TITLE
Make colours independant of the Gtk theme

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -44,10 +44,12 @@ static gboolean sunclock_gui_draw_shade(GtkWidget* widget, cairo_t* cr,
     cairo_paint(cr);
     g_object_unref(image_scaled);
 
-    GtkStyleContext* context = gtk_widget_get_style_context(widget);
-    GtkStateFlags state = gtk_style_context_get_state(context);
     GdkRGBA colour;
-    gtk_style_context_get_color(context, state, &colour);
+    colour.red = 0.933333;
+    colour.green = 0.933333;
+    colour.blue = 0.925490;
+    colour.alpha = 1.0;
+
     gdk_cairo_set_source_rgba(cr, &colour);
 
     // calculate the illuminated area


### PR DESCRIPTION
In some themes, the colour obtained from gtk_style_context_get_color() and used for the illuminated area is darker than the background.

This is counter intuitive.

Since we're working with a hardcoded background image, I think we can hardcode the colour for the illuminated area. These values were obtained from the Adwaita-dark theme and seem to give a reasonable result - but anything lighter than the background would do.